### PR TITLE
Make flask-permissions work with an existing user table, rather than creating its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,8 @@ Installs quickly and easily using PIP:
         class User(UserMixin):
             # Add whatever fields you need for your user class here.
 
-            # Identify the class to differentiate between sub-types of the UserMixin.
-            __mapper_args__ = {
-                'polymorphic_identity': 'user' # This can be any unique value except 'usermixin'.
-            }
-
-            def __init__(self, email, password, roles=None):
+            def __init__(self, ...):
+                # Do your user init
                 UserMixin.__init__(self, roles)
 
 5. Add roles to your users and abilities to your roles. This can be done using convenience methods on the `UserMixin` and `Role` classes.
@@ -55,9 +51,9 @@ Installs quickly and easily using PIP:
         db.session.add(my_role)
         db.session.commit()
 
-    Add roles on a `UserMixin` instance or on an instance of your `UserMixin` sub-class.
+    Add roles on an instance of your `UserMixin` sub-class.
 
-        my_user = UserMixin()
+        my_user = User()
 
     The `user.add_roles()` method works just like `role.add_abilities()`. Pass in a string name or a series of string names. New roles will be created for you. Existing roles will simply be applied to the user. Don't forget to add and commit to the database!
 

--- a/flask_permissions/models.py
+++ b/flask_permissions/models.py
@@ -1,4 +1,3 @@
-from sqlalchemy.ext.hybrid import hybrid_property
 
 try:
     from .core import db
@@ -7,6 +6,7 @@ except ImportError:
         'Permissions app must be initialized before importing models')
 
 from werkzeug import generate_password_hash, check_password_hash
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
 from .utils import is_sequence

--- a/flask_permissions/models.py
+++ b/flask_permissions/models.py
@@ -154,9 +154,3 @@ class UserMixin(db.Model):
 
     def remove_roles(self, *roles):
         self.roles = [role for role in self.roles if role not in roles]
-
-    def get_id(self):
-        return unicode(self.id)
-
-    def __repr__(self):
-        return '<User {}>'.format(self.id)

--- a/flask_permissions/models.py
+++ b/flask_permissions/models.py
@@ -110,7 +110,18 @@ class UserMixin(db.Model):
 
     @hybrid_property
     def _id_column_name(self):
-        for k, v in self.__dict__.items():
+
+        # the list of the class's columns (with attributes like
+        # 'primary_key', etc.) is accessible in different places
+        # before and after table definition.
+        if self.__tablename__ in self.metadata.tables.keys():
+            # after definition, it's here
+            columns = self.metadata.tables[self.__tablename__]._columns
+        else:
+            # before, it's here
+            columns = self.__dict__
+
+        for k, v in columns.items():
             if getattr(v, 'primary_key', False):
                 return k
 
@@ -154,3 +165,9 @@ class UserMixin(db.Model):
 
     def remove_roles(self, *roles):
         self.roles = [role for role in self.roles if role not in roles]
+
+    def get_id(self):
+        return unicode(getattr(self, self._id_column_name))
+
+    def __repr__(self):
+        return '<{} {}>'.format(self.__tablename__.capitalize(), self.get_id())

--- a/flask_permissions/tests.py
+++ b/flask_permissions/tests.py
@@ -2,6 +2,7 @@ from flask import Flask
 import unittest
 from flask_testing import TestCase as FlaskTestCase
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Column, Integer
 from .core import Permissions
 from .utils import is_sequence
 from .decorators import user_has, user_is
@@ -22,6 +23,10 @@ perms = Permissions(app, db, None)
 from .models import Role, Ability, UserMixin
 
 
+class User(UserMixin):
+    id = Column(Integer, primary_key=True)
+
+
 class DatabaseTests(FlaskTestCase):
 
     def create_app(self):
@@ -37,7 +42,7 @@ class DatabaseTests(FlaskTestCase):
 class ModelsTests(DatabaseTests):
 
     def test_user_mixin(self):
-        user = UserMixin()
+        user = User()
         db.session.add(user)
         db.session.commit()
         self.assertEqual(user.id, 1)
@@ -48,7 +53,7 @@ class ModelsTests(DatabaseTests):
             new_role = Role(role)
             db.session.add(new_role)
             db.session.commit()
-        user = UserMixin(roles=roles, default_role=None)
+        user = User(roles=roles, default_role=None)
         db.session.add(user)
         db.session.commit()
         self.assertEqual(user.id, 1)
@@ -57,31 +62,31 @@ class ModelsTests(DatabaseTests):
         new_role = Role('admin')
         db.session.add(new_role)
         db.session.commit()
-        user = UserMixin(roles='admin', default_role=None)
+        user = User(roles='admin', default_role=None)
         db.session.add(user)
         db.session.commit()
         self.assertEqual(user.id, 1)
 
     def test_user_is_authenticated(self):
-        user = UserMixin()
+        user = User()
         self.assertTrue(user.is_authenticated())
 
     def test_user_is_active(self):
-        user = UserMixin()
+        user = User()
         self.assertTrue(user.is_active())
 
     def test_user_is_not_anonymous(self):
-        user = UserMixin()
+        user = User()
         self.assertFalse(user.is_anonymous())
 
     def test_user_get_id(self):
-        user = UserMixin()
+        user = User()
         db.session.add(user)
         db.session.commit()
         self.assertEqual(user.get_id(), unicode(1))
 
     def test_user_repr(self):
-        user = UserMixin()
+        user = User()
         db.session.add(user)
         db.session.commit()
         self.assertEqual(user.__repr__(), '<User 1>')
@@ -115,16 +120,16 @@ class ModelsTests(DatabaseTests):
         self.assertEqual(ability.__str__(), 'create_users')
 
     def test_add_roles_with_nonexisting_roles(self):
-        user = UserMixin(default_role=None)
+        user = User(default_role=None)
         new_roles = ['admin', 'superadmin', 'editor']
         user.add_roles(*new_roles)
         db.session.add(user)
         db.session.commit()
-        test_user = UserMixin.query.get(1)
+        test_user = User.query.get(1)
         self.assertItemsEqual(new_roles, test_user.roles)
 
     def test_add_roles_with_existing_roles(self):
-        user = UserMixin(default_role=None)
+        user = User(default_role=None)
         new_roles = ['admin', 'superadmin', 'editor']
         for role in new_roles:
             new_role = Role(role)
@@ -133,20 +138,20 @@ class ModelsTests(DatabaseTests):
         user.add_roles(*new_roles)
         db.session.add(user)
         db.session.commit()
-        test_user = UserMixin.query.get(1)
+        test_user = User.query.get(1)
         self.assertItemsEqual(new_roles, test_user.roles)
 
     def test_remove_roles(self):
-        user = UserMixin()
+        user = User()
         new_roles = ['admin', 'user', 'superadmin']
         user.add_roles(*new_roles)
         db.session.add(user)
         db.session.commit()
-        role_remove_user = UserMixin.query.get(1)
+        role_remove_user = User.query.get(1)
         role_remove_user.remove_roles('user', 'admin')
         db.session.add(user)
         db.session.commit()
-        test_user = UserMixin.query.get(1)
+        test_user = User.query.get(1)
         self.assertItemsEqual(test_user.roles, ['superadmin'])
 
     def test_add_abilities_with_nonexisting_abilities(self):
@@ -204,12 +209,12 @@ class DecoratorsTests(DatabaseTests):
         db.session.add(role)
         db.session.commit()
 
-        user = UserMixin(roles='admin')
+        user = User(roles='admin')
         db.session.add(user)
         db.session.commit()
 
     def return_user(self):
-        user = UserMixin.query.get(1)
+        user = User.query.get(1)
         return user
 
     def setUp(self):

--- a/flask_permissions/tests.py
+++ b/flask_permissions/tests.py
@@ -1,7 +1,7 @@
 from flask import Flask
 import unittest
-from flask.ext.testing import TestCase as FlaskTestCase
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_testing import TestCase as FlaskTestCase
+from flask_sqlalchemy import SQLAlchemy
 from .core import Permissions
 from .utils import is_sequence
 from .decorators import user_has, user_is


### PR DESCRIPTION
I wanted to use my own user table, and not have to work with the fp_user one.